### PR TITLE
docs: readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 # rsk3.js - RSK Javascript API
+
 ## Installation
-`npm install rsk3`
+
+```shell
+npm install rsk3
+```
 
 ## Usage
-```
+
+```javascript
 import Rsk3 from 'rsk3';
 
 // Create a Rsk3 instance
 const rsk3Instance = new Rsk3('http://localhost:4444');
 
-// Get gas estimate 
+// Get gas estimate
 const gas = await rsk3Instance.estimateGas(txObject);
 console.log('gas', gas);
 > 5940000
@@ -27,8 +32,10 @@ Rsk3.utils.isAddress('0xCd2a3D9f938e13Cd947EC05aBc7fE734df8dD826');
 ```
 
 ## Example
+
 This example shows a complete code snippet to construct and send a transaction with Rsk3.
-```
+
+```javascript
 import Rsk3 from 'rsk3';
 const rsk3 = new Rsk3('http://localhost:4444');
 const publicKey = '';
@@ -84,26 +91,48 @@ await new Promise((resolve, reject) => {
 
 ## Commands
 
-- npm run bootstrap # install all dependencies for npm run bootstrap
-- npm run lint # Examine formatting of source code using eslint
-- npm run test # runs all tests 
-- npm run clean # removes all the node_modules folders in all modules
+Install all dependencies for `npm run bootstrap`
 
+```shell
+npm run bootstrap
+```
+
+Examine formatting of source code using `eslint`
+
+```shell
+npm run lint
+```
+
+Run all tests
+
+```shell
+npm run test
+```
+
+Remove all the `node_modules` folders in all modules
+
+```shell
+npm run clean
+```
 
 ## Testing
 
 Testing is done using `jest`. The configuration file `jest.config.js` and `jest.preprocessor.js` apply to tests in all packages.
 
 To run all tests, under the root run
+
 1. `npm run bootstrap`
 1. `npm run test` OR `npm run test:coverage`
 
 To run single package tests, under the root run
+
 1. `npm run bootstrap`
 1. `npx lerna run --scope package_name test`
 
 ## Formatting
+
 Code Formatting is done using `eslint`. `.eslintrc.json` under root configures formatting rules for the whole project, and `.eslintignore` file exclude files watched by eslint.
 
 ## Note
+
 The majority of code in packages are similar to those with the same name in Web3.js, and will be upgraded in sync with Web3.js

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ await new Promise((resolve, reject) => {
 
 
 ## Testing
-Testing is done using `jest`. The configuration file `jest.config.js` and `jesy.preprocessor.js` apply to tests in all packages. 
+
+Testing is done using `jest`. The configuration file `jest.config.js` and `jest.preprocessor.js` apply to tests in all packages.
 
 To run all tests, under the root run
 1. `npm run bootstrap`


### PR DESCRIPTION
## What

- Improved markdown formatting
- Correction `jesy` -> `jest`

## Why

- Maximise compatibility with other markdown processing engines
- Make code blocks render with syntax highlights

## Refs

- [Task](https://trello.com/c/IMM75iqF/220)
