### PR TITLE
strengthen jest testMatch 

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@ const config = {
     clearMocks: true,
     resetMocks: true,
     resetModules: true,
-    testMatch: ['/**/*.test.js'],
+    testMatch: ['./**/*.test.js'],
     transform: {
         '^.+\\.js$': '<rootDir>/../../jest.preprocessor.js'
     },


### PR DESCRIPTION
strengthen jest testMatch  which cause 'No tests found, exiting with code 1' on windows 10 platform

On my windows platform, I got this error when I run `npm run test` command.

![image](https://user-images.githubusercontent.com/13350957/77027812-2d2a0a80-69d2-11ea-9361-f14e6580caa5.png)


