### PR TITLE
proj: update project URLs in package.json for all modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rootstock/rsk3.js.git"
+    "url": "git+https://github.com/rsksmart/rsk3.js.git"
   },
   "keywords": [
     "RSK",
@@ -32,9 +32,9 @@
   "author": "RSK Innovation Labs",
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/rootstock/rsk3.js/issues"
+    "url": "https://github.com/rsksmart/rsk3.js/issues"
   },
-  "homepage": "https://github.com/rootstock/rsk3.js#readme",
+  "homepage": "https://github.com/rsksmart/rsk3.js#readme",
   "devDependencies": {
     "@babel/core": "^7.4.4",
     "@babel/plugin-proposal-export-default-from": "^7.2.0",

--- a/packages/rsk3-abi/package.json
+++ b/packages/rsk3-abi/package.json
@@ -5,7 +5,7 @@
   "description": "Rsk3 module to interact with the RSK nodes networking properties.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rootstock/rsk3.js.git"
+    "url": "git+https://github.com/rsksmart/rsk3.js.git"
   },
   "engines": {
     "node": ">=8.6.0"
@@ -25,11 +25,11 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/rootstock/rsk3.js/tree/master/packages/rsk3-abi#readme",
+  "homepage": "https://github.com/rsksmart/rsk3.js/tree/master/packages/rsk3-abi#readme",
   "main": "dist/rsk3-abi.cjs.js",
   "module": "dist/rsk3-abi.esm.js",
   "browser": "dist/rsk3-abi.umd.js",
   "bugs": {
-    "url": "https://github.com/rootstock/rsk3.js/issues"
+    "url": "https://github.com/rsksmart/rsk3.js/issues"
   }
 }

--- a/packages/rsk3-account/package.json
+++ b/packages/rsk3-account/package.json
@@ -5,7 +5,7 @@
   "description": "Rsk3 module to interact with the RSK nodes networking properties.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rootstock/rsk3.js.git"
+    "url": "git+https://github.com/rsksmart/rsk3.js.git"
   },
   "engines": {
     "node": ">=8.6.0"
@@ -34,11 +34,11 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/rootstock/rsk3.js/tree/master/packages/rsk3-account#readme",
+  "homepage": "https://github.com/rsksmart/rsk3.js/tree/master/packages/rsk3-account#readme",
   "main": "dist/rsk3-account.cjs.js",
   "module": "dist/rsk3-account.esm.js",
   "browser": "dist/rsk3-account.umd.js",
   "bugs": {
-    "url": "https://github.com/rootstock/rsk3.js/issues"
+    "url": "https://github.com/rsksmart/rsk3.js/issues"
   }
 }

--- a/packages/rsk3-contract/package.json
+++ b/packages/rsk3-contract/package.json
@@ -5,7 +5,7 @@
   "description": "Rsk3 module to interact with the RSK nodes networking properties.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rootstock/rsk3.js.git"
+    "url": "git+https://github.com/rsksmart/rsk3.js.git"
   },
   "engines": {
     "node": ">=8.6.0"
@@ -32,11 +32,11 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/rootstock/rsk3.js/tree/master/packages/rsk3-contract#readme",
+  "homepage": "https://github.com/rsksmart/rsk3.js/tree/master/packages/rsk3-contract#readme",
   "main": "dist/rsk3-contract.cjs.js",
   "module": "dist/rsk3-contract.esm.js",
   "browser": "dist/rsk3-contract.umd.js",
   "bugs": {
-    "url": "https://github.com/rootstock/rsk3.js/issues"
+    "url": "https://github.com/rsksmart/rsk3.js/issues"
   }
 }

--- a/packages/rsk3-net/package.json
+++ b/packages/rsk3-net/package.json
@@ -5,7 +5,7 @@
   "description": "Rsk3 module to interact with the RSK nodes networking properties.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rootstock/rsk3.js.git"
+    "url": "git+https://github.com/rsksmart/rsk3.js.git"
   },
   "engines": {
     "node": ">=8.6.0"
@@ -28,11 +28,11 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/rootstock/rsk3.js/tree/master/packages/rsk3-net#readme",
+  "homepage": "https://github.com/rsksmart/rsk3.js/tree/master/packages/rsk3-net#readme",
   "main": "dist/rsk3-net.cjs.js",
   "module": "dist/rsk3-net.esm.js",
   "browser": "dist/rsk3-net.umd.js",
   "bugs": {
-    "url": "https://github.com/rootstock/rsk3.js/issues"
+    "url": "https://github.com/rsksmart/rsk3.js/issues"
   }
 }

--- a/packages/rsk3-personal/package.json
+++ b/packages/rsk3-personal/package.json
@@ -30,15 +30,15 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/rootstock/rsk3.js/tree/master/packages/rsk3-personal#readme",
+  "homepage": "https://github.com/rsksmart/rsk3.js/tree/master/packages/rsk3-personal#readme",
   "main": "dist/rsk3-personal.cjs.js",
   "module": "dist/rsk3-personal.esm.js",
   "browser": "dist/rsk3-personal.umd.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rootstock/rsk3.js.git"
+    "url": "git+https://github.com/rsksmart/rsk3.js.git"
   },
   "bugs": {
-    "url": "https://github.com/rootstock/rsk3.js/issues"
+    "url": "https://github.com/rsksmart/rsk3.js/issues"
   }
 }

--- a/packages/rsk3-utils/package.json
+++ b/packages/rsk3-utils/package.json
@@ -5,7 +5,7 @@
   "description": "Rsk3 module to interact with the RSK nodes networking properties.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rootstock/rsk3.js.git"
+    "url": "git+https://github.com/rsksmart/rsk3.js.git"
   },
   "engines": {
     "node": ">=8.6.0"
@@ -32,7 +32,7 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/rootstock/rsk3.js/tree/master/packages/rsk3-utils#readme",
+  "homepage": "https://github.com/rsksmart/rsk3.js/tree/master/packages/rsk3-utils#readme",
   "main": "dist/rsk3-utils.cjs.js",
   "module": "dist/rsk3-utils.esm.js",
   "browser": "dist/rsk3-utils.umd.js"

--- a/packages/rsk3/package.json
+++ b/packages/rsk3/package.json
@@ -2,13 +2,13 @@
   "name": "rsk3",
   "version": "0.1.2",
   "description": "Rsk3 module to interact with the RSK nodes networking properties.",
-  "homepage": "https://github.com/rootstock/rsk3.js/tree/master/packages/rsk3#readme",
+  "homepage": "https://github.com/rsksmart/rsk3.js/tree/master/packages/rsk3#readme",
   "bugs": {
-    "url": "https://github.com/rootstock/rsk3.js/issues"
+    "url": "https://github.com/rsksmart/rsk3.js/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rootstock/rsk3.js.git"
+    "url": "git+https://github.com/rsksmart/rsk3.js.git"
   },
   "license": "LGPL-3.0",
   "files": [


### PR DESCRIPTION
## What

- update `package.json` and `packages/rsk3*/package.json` to update the repository URL
  - `github.com/rootstock/rsk3.js` --> `github.com/rsksmart/rsk3.js`

## Why

- ensure that link is displayed correctly in package manager (npm)
