### PR TITLE
docs: update import and require statements to use scoped package names

### DIFF
--- a/docs/rsk3-abi.md
+++ b/docs/rsk3-abi.md
@@ -7,7 +7,7 @@ a ABI (Application Binary Interface). This will be used for calling
 functions of a deployed smart-contract.
 
 ``` javascript
-import {AbiCoder} from 'rsk3-abi';
+import {AbiCoder} from '@rsksmart/rsk3-abi';
 
 const abiCoder = new AbiCoder();
 
@@ -15,7 +15,7 @@ const abiCoder = new AbiCoder();
 
 ------------------------------------------------------------------------
 
-encodeFunctionSignature 
+encodeFunctionSignature
 =======================
 
 ``` javascript

--- a/docs/rsk3-account.md
+++ b/docs/rsk3-account.md
@@ -13,7 +13,7 @@ properly, store the private keys safely, and test transaction receiving
 and sending functionality properly before using in production!
 
 ``` javascript
-import {Accounts} from 'rsk3-accounts';
+import {Accounts} from '@rsksmart/rsk3-accounts';
 
 // Passing in the eth or rsk3 package is necessary to allow retrieving chainId, gasPrice and nonce automatically
 // for accounts.signTransaction().
@@ -132,7 +132,7 @@ Signs an Ethereum transaction with a given private key.
 
 ### Parameters
 
-1.  
+1.
     `tx` - `Object`: The transaction\'s properties object as follows:
 
     :   -   `nonce` - `String`: (optional) The nonce to use when signing
@@ -326,7 +326,7 @@ Recovers the Ethereum address which was used to sign the given data.
 
 ### Parameters
 
-1.  
+1.
 
     `message|signatureObject` - `String|Object`: Either signed message or hash, or the signature object as following values:
 

--- a/docs/rsk3-contract.md
+++ b/docs/rsk3-contract.md
@@ -15,8 +15,8 @@ JavaScript objects.
 To use it standalone:
 
 ``` javascript
-import {Contract} from 'rsk3-contract';
-import {Accounts} from 'rsk3-account;}
+import {Contract} from '@rsksmart/rsk3-contract';
+import {Accounts} from '@rsksmart/rsk3-account';
 const contract = new Contract(
     'ws://localhost:8546',
     new Accounts('ws://localhost:8546', options),
@@ -49,7 +49,7 @@ in its `json interface` object.
 2.  `address` - `String` (optional): This address is necessary for
     transactions and call requests and can also be added later using
     `myContract.options.address = '0x1234..'.`
-3.  
+3.
     `options` - `Object` (optional): The options of the contract. Some are used as fallbacks for calls and transactions:
 -   `data` - `String`: The byte code of the contract. Used when
             the contract gets
@@ -225,7 +225,7 @@ instance.
 
 ### Parameters
 
-1.  
+1.
 
     `options` - `Object`: The options used for deployment.
 
@@ -485,7 +485,7 @@ Note this can alter the smart contract state.
 
 ### Parameters
 
-1.  
+1.
 
     `options` - `Object`: The options used for sending.
 
@@ -607,7 +607,7 @@ the smart contract can be different at that time.
 
 ### Parameters
 
-1.  
+1.
 
     `options` - `Object` (optional): The options used for calling.
 
@@ -695,7 +695,7 @@ event or error. Will only fire for a single event.
 
 1.  `event` - `String`: The name of the event in the contract, or
     `"allEvents"` to get all events.
-2.  
+2.
 
     `options` - `Object` (optional): The options used for deployment.
 
@@ -759,7 +759,7 @@ Subscribe to an event
 
 ### Parameters
 
-1.  
+1.
 
     `options` - `Object` (optional): The options used for deployment.
 
@@ -877,7 +877,7 @@ Gets past events for this contract.
 
 1.  `event` - `String`: The name of the event in the contract, or
     `"allEvents"` to get all events.
-2.  
+2.
 
     `options` - `Object` (optional): The options used for deployment.
 

--- a/docs/rsk3-personal.md
+++ b/docs/rsk3-personal.md
@@ -12,7 +12,7 @@ call these functions over a unsecured Websocket or HTTP provider, as
 your password will be sent in plain text!
 
 ``` javascript
-import {Personal} from 'rsk3-personal';
+import {Personal} from '@rsksmart/rsk3-personal';
 
 const personal = new Personal('ws://some.local-or-remote.node:8546', null, options);
 

--- a/docs/rsk3.md
+++ b/docs/rsk3.md
@@ -7,7 +7,7 @@ The `rsk3` allows you to interact with a Rsk
 blockchain itself and the deployed smart contracts.
 
 ``` javascript
-import {Rsk3} from 'rsk3';
+import {Rsk3} from '@rsksmart/rsk3';
 
 
 const rsk3 = new Rsk3('ws://some.local-or-remote.node:8546', null, options);
@@ -91,7 +91,7 @@ An Rsk3 module does provide several options for configuring the
 transaction confirmation worklfow or for defining default values. These
 are the currently available option properties on a Rsk3 module:
 
-### Module Options 
+### Module Options
 
 `defaultAccount`
 
@@ -130,7 +130,7 @@ const rsk3 = new Rsk3('http://localhost:8545', null, options);
 
 ------------------------------------------------------------------------
 
-defaultBlock 
+defaultBlock
 ------------
 
 ``` javascript
@@ -166,7 +166,7 @@ Default is `"latest"`
 
 ------------------------------------------------------------------------
 
-defaultAccount 
+defaultAccount
 --------------
 
 ``` javascript
@@ -184,7 +184,7 @@ key for that address in your node or keystore. (Default is `undefined`)
 
 ------------------------------------------------------------------------
 
-defaultGasPrice 
+defaultGasPrice
 ---------------
 
 ``` javascript
@@ -200,7 +200,7 @@ The default gas price which will be used for a request.
 
 ------------------------------------------------------------------------
 
-defaultGas 
+defaultGas
 ----------
 
 ``` javascript
@@ -236,7 +236,7 @@ rejects with a timeout error when the timeout got exceeded.
 ------------------------------------------------------------------------
 
 
-transactionConfirmationBlocks 
+transactionConfirmationBlocks
 
 ``` javascript
 rsk3.transactionConfirmationBlocks
@@ -253,7 +253,7 @@ be handled as confirmed.
 ------------------------------------------------------------------------
 
 
-transactionPollingTimeout 
+transactionPollingTimeout
 
 ``` javascript
 rsk3.transactionPollingTimeout
@@ -270,7 +270,7 @@ until the first confirmation happens.
 
 ------------------------------------------------------------------------
 
-transactionSigner 
+transactionSigner
 -----------------
 
 ``` javascript
@@ -941,7 +941,7 @@ Returns a transaction matching the given transaction hash.
 2.  `Function` - (optional) Optional callback, returns an error object
     as first parameter and the result as second.
 
-### Returns 
+### Returns
 
 `Promise<object>` - A transaction object its hash `transactionHash`:
 
@@ -985,7 +985,7 @@ rsk3.getTransaction('0x9fc76417374aa880d4449a1f7f31ec597f00b1f6f3dd2d66f4c9c6c44
 
 ------------------------------------------------------------------------
 
-getPendingTransactions 
+getPendingTransactions
 ----------------------
 
 ``` javascript
@@ -999,7 +999,7 @@ Returns a list of pending transactions.
 1.  `Function` - (optional) Optional callback, returns an error object
     as first parameter and the result as second.
 
-### Returns 
+### Returns
 
 `Promise<object[]>` - Array of pending transactions:
 
@@ -1116,7 +1116,7 @@ The receipt is not available for pending transactions and returns
 2.  `Function` - (optional) Optional callback, returns an error object
     as first parameter and the result as second.
 
-### Returns 
+### Returns
 
 `Promise` returns `Object` - A transaction receipt object, or `null`
 when no receipt was found:
@@ -1164,7 +1164,7 @@ const receipt = rsk3.getTransactionReceipt('0x9fc76417374aa880d4449a1f7f31ec597f
 
 ------------------------------------------------------------------------
 
-getTransactionCount 
+getTransactionCount
 -------------------
 
 ``` javascript
@@ -1196,7 +1196,7 @@ rsk3.getTransactionCount("0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe").then(cons
 
 ------------------------------------------------------------------------
 
-sendTransaction 
+sendTransaction
 ---------------
 
 ``` javascript
@@ -1245,7 +1245,7 @@ The `from` property can also be an address or index from the
 account, and send the transaction via
 `rsk3.sendSignedTransaction()`
 
-### Returns 
+### Returns
 
 The **callback** will return the 32 bytes transaction hash.
 
@@ -1310,7 +1310,7 @@ rsk3.sendTransaction({
 
 ------------------------------------------------------------------------
 
-sendSignedTransaction 
+sendSignedTransaction
 ---------------------
 
 ``` javascript
@@ -1570,7 +1570,7 @@ Gets past logs, matching the given options.
         pass an array for each topic with options for that topic e.g.
         `[null, ['option1', 'option2']]`
 
-### Returns 
+### Returns
 
 `Promise<Array>` - Array of log objects.
 

--- a/packages/rsk3-abi/README.md
+++ b/packages/rsk3-abi/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```
-const rsk3Abi = require('rsk3-abi');
+const rsk3Abi = require('@rsksmart/rsk3-abi');
 
 // TODO: DEMONSTRATE API
 ```

--- a/packages/rsk3-account/README.md
+++ b/packages/rsk3-account/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```
-const rsk3Account = require('rsk3-account');
+const rsk3Account = require('@rsksmart/rsk3-account');
 
 // TODO: DEMONSTRATE API
 ```

--- a/packages/rsk3-contract/README.md
+++ b/packages/rsk3-contract/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```
-const rsk3Contract = require('rsk3-contract');
+const rsk3Contract = require('@rsksmart/rsk3-contract');
 
 // TODO: DEMONSTRATE API
 ```

--- a/packages/rsk3-net/README.md
+++ b/packages/rsk3-net/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```
-const rsk3Net = require('rsk3-net');
+const rsk3Net = require('@rsksmart/rsk3-net');
 
 // TODO: DEMONSTRATE API
 ```

--- a/packages/rsk3-personal/README.md
+++ b/packages/rsk3-personal/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```
-const rsk3Personal = require('rsk3-personal');
+const rsk3Personal = require('@rsksmart/rsk3-personal');
 
 // TODO: DEMONSTRATE API
 ```

--- a/packages/rsk3-utils/README.md
+++ b/packages/rsk3-utils/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```
-const rsk3Utils = require('rsk3-utils');
+const rsk3Utils = require('@rsksmart/rsk3-utils');
 
 // TODO: DEMONSTRATE API
 ```


### PR DESCRIPTION
## What

- Update documentation of import and require statements to use scoped package names

## Why

- packages will soon be published under a scoped package name,
  and current documentation will not work any more

## Refs

- Related PRs: [#35](https://github.com/rsksmart/rsk3.js/pull/35)