### PR TITLE
proj: new run script to bootstrap using yarn instead of npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ Install all dependencies for `npm run bootstrap`
 npm run bootstrap
 ```
 
+If you encounter an error:
+"Maximum call stack size exceeded", you may wish to use
+[`yarn`](https://yarnpkg.com/)
+for the bootstrap process:
+
+```shell
+npm run bootstrap-yarn
+```
+
 Examine formatting of source code using `eslint`
 
 ```shell

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "bootstrap-local": "lerna bootstrap --force-local",
     "bootstrap": "lerna bootstrap",
+    "bootstrap-yarn": "lerna bootstrap --npm-client yarn  -- --no-lockfile",
     "build": "lerna run build",
     "release": "lerna version --no-git-tag-version",
     "publish": "lerna publish from-git",


### PR DESCRIPTION
## What

- Add `bootstrap-yarn` command to complement the existing `bootstrap` npm run script
- Update README for usage

## Why

- this avoids the error which may be encountered in npm:
  - `Maximum call stack size exceeded`
