### PR TITLE
docs: update package readmes

### DIFF
--- a/docs/rsk3.md
+++ b/docs/rsk3.md
@@ -1,5 +1,3 @@
-
-
 rsk3
 ========
 
@@ -112,7 +110,7 @@ are the currently available option properties on a Rsk3 module:
 ### Example
 
 ``` javascript
-import {Rsk3} from 'rsk3';
+import {Rsk3} from '@rsksmart/rsk3';
 
 const options = {
     defaultAccount: '0x0',
@@ -329,7 +327,7 @@ Will change the provider for its module.
 ### Example
 
 ``` javascript
-import {Rsk3} from 'rsk3';
+import {Rsk3} from '@rsksmart/rsk3';
 
 const rsk3 = new Rsk3('http://localhost:8545');
 
@@ -373,7 +371,7 @@ Contains the current available providers.
 ### Example
 
 ``` javascript
-const {Rsk3} = require('rsk3');
+const {Rsk3} = require('@rsksmart/rsk3');
 
 
 // Using the IPC provider in node.js

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lerna": "2.0.0",
   "command": {
     "init": {

--- a/packages/rsk3-abi/README.md
+++ b/packages/rsk3-abi/README.md
@@ -1,11 +1,3 @@
 # `rsk3-abi`
 
-> TODO: description
-
-## Usage
-
-```
-const rsk3Abi = require('@rsksmart/rsk3-abi');
-
-// TODO: DEMONSTRATE API
-```
+[Documentation](https://developers.rsk.co/libraries/rsk3js/docs/rsk3-abi/)

--- a/packages/rsk3-abi/package-lock.json
+++ b/packages/rsk3-abi/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rsksmart/rsk3-abi",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/rsk3-abi/package.json
+++ b/packages/rsk3-abi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rsksmart/rsk3-abi",
   "namespace": "RSK",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Rsk3 module to interact with the RSK nodes networking properties.",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "@rsksmart/rsk3-utils": "0.3.0",
+    "@rsksmart/rsk3-utils": "0.3.1",
     "ethers": "^4.0.27",
     "lodash": "^4.17.11"
   },

--- a/packages/rsk3-account/README.md
+++ b/packages/rsk3-account/README.md
@@ -1,11 +1,3 @@
 # `rsk3-account`
 
-> TODO: description
-
-## Usage
-
-```
-const rsk3Account = require('@rsksmart/rsk3-account');
-
-// TODO: DEMONSTRATE API
-```
+[Documentation](https://developers.rsk.co/libraries/rsk3js/docs/rsk3-account/)

--- a/packages/rsk3-account/package-lock.json
+++ b/packages/rsk3-account/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rsksmart/rsk3-account",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/rsk3-account/package.json
+++ b/packages/rsk3-account/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rsksmart/rsk3-account",
   "namespace": "RSK",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Rsk3 module to interact with the RSK nodes networking properties.",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "@rsksmart/rsk3-utils": "0.3.0",
+    "@rsksmart/rsk3-utils": "0.3.1",
     "browserify-cipher": "^1.0.1",
     "eth-lib": "0.2.8",
     "lodash": "^4.17.11",

--- a/packages/rsk3-contract/README.md
+++ b/packages/rsk3-contract/README.md
@@ -1,11 +1,3 @@
 # `rsk3-contract`
 
-> TODO: description
-
-## Usage
-
-```
-const rsk3Contract = require('@rsksmart/rsk3-contract');
-
-// TODO: DEMONSTRATE API
-```
+[Documentation](https://developers.rsk.co/libraries/rsk3js/docs/rsk3-contract/)

--- a/packages/rsk3-contract/package-lock.json
+++ b/packages/rsk3-contract/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rsksmart/rsk3-contract",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/rsk3-contract/package.json
+++ b/packages/rsk3-contract/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rsksmart/rsk3-contract",
   "namespace": "RSK",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Rsk3 module to interact with the RSK nodes networking properties.",
   "repository": {
     "type": "git",
@@ -18,9 +18,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "@rsksmart/rsk3-abi": "0.3.0",
-    "@rsksmart/rsk3-account": "0.3.0",
-    "@rsksmart/rsk3-utils": "0.3.0",
+    "@rsksmart/rsk3-abi": "0.3.1",
+    "@rsksmart/rsk3-account": "0.3.1",
+    "@rsksmart/rsk3-utils": "0.3.1",
     "@types/bn.js": "^4.11.4",
     "lodash": "^4.17.11",
     "web3-core": "2.0.0-alpha.1",

--- a/packages/rsk3-net/README.md
+++ b/packages/rsk3-net/README.md
@@ -1,11 +1,3 @@
 # `rsk3-net`
 
-> TODO: description
-
-## Usage
-
-```
-const rsk3Net = require('@rsksmart/rsk3-net');
-
-// TODO: DEMONSTRATE API
-```
+[Documentation](https://developers.rsk.co/libraries/rsk3js/docs/rsk3-net/)

--- a/packages/rsk3-net/package-lock.json
+++ b/packages/rsk3-net/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rsksmart/rsk3-net",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/rsk3-net/package.json
+++ b/packages/rsk3-net/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rsksmart/rsk3-net",
   "namespace": "RSK",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Rsk3 module to interact with the RSK nodes networking properties.",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "@rsksmart/rsk3-utils": "0.3.0",
+    "@rsksmart/rsk3-utils": "0.3.1",
     "lodash": "^4.17.11",
     "web3-core": "2.0.0-alpha.1",
     "web3-core-helpers": "2.0.0-alpha.1",

--- a/packages/rsk3-personal/README.md
+++ b/packages/rsk3-personal/README.md
@@ -1,11 +1,3 @@
 # `rsk3-personal`
 
-> TODO: description
-
-## Usage
-
-```
-const rsk3Personal = require('@rsksmart/rsk3-personal');
-
-// TODO: DEMONSTRATE API
-```
+[Documentation](https://developers.rsk.co/libraries/rsk3js/docs/rsk3-personal/)

--- a/packages/rsk3-personal/package-lock.json
+++ b/packages/rsk3-personal/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "rsk3-personal",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/rsk3-personal/package.json
+++ b/packages/rsk3-personal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rsk3-personal",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "rsk3 module to interact with the Ethereum blockchain accounts stored in the node.",
   "engines": {
     "node": ">=8.6.0"
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "@rsksmart/rsk3-account": "0.3.0",
-    "@rsksmart/rsk3-utils": "0.3.0",
+    "@rsksmart/rsk3-account": "0.3.1",
+    "@rsksmart/rsk3-utils": "0.3.1",
     "web3-core": "2.0.0-alpha.1",
     "web3-core-helpers": "2.0.0-alpha.1",
     "web3-core-method": "2.0.0-alpha.1",

--- a/packages/rsk3-utils/README.md
+++ b/packages/rsk3-utils/README.md
@@ -1,11 +1,3 @@
 # `rsk3-utils`
 
-> TODO: description
-
-## Usage
-
-```
-const rsk3Utils = require('@rsksmart/rsk3-utils');
-
-// TODO: DEMONSTRATE API
-```
+[Documentation](https://developers.rsk.co/libraries/rsk3js/docs/rsk3-utils/)

--- a/packages/rsk3-utils/package-lock.json
+++ b/packages/rsk3-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rsksmart/rsk3-utils",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/rsk3-utils/package.json
+++ b/packages/rsk3-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rsksmart/rsk3-utils",
   "namespace": "RSK",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Rsk3 module to interact with the RSK nodes networking properties.",
   "repository": {
     "type": "git",

--- a/packages/rsk3/README.md
+++ b/packages/rsk3/README.md
@@ -1,11 +1,3 @@
 # `rsk3`
 
-> TODO: description
-
-## Usage
-
-```
-const rsk3 = require('rsk3');
-
-// TODO: DEMONSTRATE API
-```
+[Documentation](https://developers.rsk.co/libraries/rsk3js/docs/rsk3/)

--- a/packages/rsk3/package-lock.json
+++ b/packages/rsk3/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "rsk3",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/rsk3/package.json
+++ b/packages/rsk3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rsk3",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Rsk3 module to interact with the RSK nodes networking properties.",
   "homepage": "https://github.com/rsksmart/rsk3.js/tree/master/packages/rsk3#readme",
   "bugs": {
@@ -24,12 +24,12 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "@rsksmart/rsk3-abi": "0.3.0",
-    "@rsksmart/rsk3-account": "0.3.0",
-    "@rsksmart/rsk3-contract": "0.3.0",
-    "@rsksmart/rsk3-net": "0.3.0",
-    "@rsksmart/rsk3-personal": "0.3.0",
-    "@rsksmart/rsk3-utils": "0.3.0",
+    "@rsksmart/rsk3-abi": "0.3.1",
+    "@rsksmart/rsk3-account": "0.3.1",
+    "@rsksmart/rsk3-contract": "0.3.1",
+    "@rsksmart/rsk3-net": "0.3.1",
+    "@rsksmart/rsk3-personal": "0.3.1",
+    "@rsksmart/rsk3-utils": "0.3.1",
     "ethereumjs-tx": "^1.3.7",
     "lodash": "^4.17.15",
     "rxjs": "^6.4.0",


### PR DESCRIPTION
## What

- Replace placeholder text in each package's README with a link to its published documentation
- Fix import statements to use scoped package name for the `rsk3` package

## Why

- Placeholder text is not very useful
- Actual documentation has not been published

## Refs

- Related PRs: [DevPortal#182](https://github.com/rsksmart/rsksmart.github.io/pull/182)