### PR TITLE
fix: regenerator runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rsk3.js",
-  "version": "0.0.8",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -835,16 +835,6 @@
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3"
-      }
-    },
-    "@babel/polyfill": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.8.7.tgz",
-      "integrity": "sha512-LeSfP9bNZH2UOZgcGcZ0PIHUt1ZuHub1L3CVmEyqLxCeDLm4C5Gi8jRH8ZX2PNpDhQCo0z6y/+DIs2JlliXW8w==",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/preset-env": {
@@ -5876,10 +5866,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-      "dev": true
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
     },
     "core-js-compat": {
       "version": "3.6.4",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@babel/plugin-proposal-export-default-from": "^7.2.0",
     "@babel/plugin-proposal-export-namespace-from": "^7.2.0",
     "@babel/plugin-transform-runtime": "^7.4.0",
-    "@babel/polyfill": "^7.4.0",
     "@babel/preset-env": "^7.4.4",
     "@babel/runtime": "^7.4.2",
     "@types/bn.js": "^4.11.5",
@@ -71,7 +70,7 @@
     "lerna": "^3.20.2",
     "lint-staged": "^8.1.0",
     "prettier": "^1.18.2",
-    "regenerator-runtime": "^0.13.3",
+    "regenerator-runtime": "^0.13.5",
     "rollup": "^1.8.0",
     "rollup-plugin-auto-external": "^2.0.0",
     "rollup-plugin-babel": "^4.3.2",
@@ -90,5 +89,8 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
+  },
+  "dependencies": {
+    "core-js": "^3.6.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/plugin-proposal-export-namespace-from": "^7.2.0",
     "@babel/plugin-transform-runtime": "^7.4.0",
     "@babel/preset-env": "^7.4.4",
-    "@babel/runtime": "^7.4.2",
+    "@babel/runtime-corejs3": "^7.9.2",
     "@types/bn.js": "^4.11.5",
     "@types/node": "^12.6.1",
     "babel-core": "^7.0.0-bridge.0",

--- a/packages/rsk3-abi/src/index.js
+++ b/packages/rsk3-abi/src/index.js
@@ -1,3 +1,6 @@
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 import * as Utils from '@rsksmart/rsk3-utils';
 import {AbiCoder as EthersAbiCoder} from 'ethers/utils/abi-coder';
 import EthAbiCoder from './abiCoder.js';

--- a/packages/rsk3-account/src/index.js
+++ b/packages/rsk3-account/src/index.js
@@ -1,3 +1,6 @@
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 import * as Utils from '@rsksmart/rsk3-utils';
 import {formatters} from 'web3-core-helpers';
 import MethodFactory from './factories/methodFactory';

--- a/packages/rsk3-contract/src/index.js
+++ b/packages/rsk3-contract/src/index.js
@@ -1,3 +1,6 @@
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 import * as Utils from '@rsksmart/rsk3-utils';
 import {formatters} from 'web3-core-helpers';
 import {AbiCoder} from '@rsksmart/rsk3-abi';

--- a/packages/rsk3-net/src/index.js
+++ b/packages/rsk3-net/src/index.js
@@ -1,3 +1,6 @@
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 import {formatters} from 'web3-core-helpers';
 import * as Utils from '@rsksmart/rsk3-utils';
 import MethodFactory from './factories/methodFactory';

--- a/packages/rsk3-personal/src/index.js
+++ b/packages/rsk3-personal/src/index.js
@@ -1,3 +1,6 @@
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 import {Network} from 'web3-net';
 import * as Utils from '@rsksmart/rsk3-utils';
 import {formatters} from 'web3-core-helpers';

--- a/packages/rsk3-utils/src/index.js
+++ b/packages/rsk3-utils/src/index.js
@@ -1,3 +1,6 @@
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 /* eslint no-useless-catch: 0 */
 import numberToBN from 'number-to-bn';
 import {isString, isNumber, isBoolean, isObject, isArray} from 'lodash';

--- a/packages/rsk3/src/index.js
+++ b/packages/rsk3/src/index.js
@@ -1,3 +1,6 @@
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 import {AbstractWeb3Module} from 'web3-core';
 import {ProviderDetector, ProvidersModuleFactory} from 'web3-providers';
 import {formatters} from 'web3-core-helpers';

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,8 +29,9 @@ const config = [
                         {
                             modules: false,
                             targets: {
+                                // Compile against node version 8 and up
                                 node: '8',
-                                browsers: 'last 2 versions'
+                                browsers: '>0.25%',
                             }
                         }
                     ]
@@ -40,6 +41,7 @@ const config = [
                     '@babel/plugin-proposal-export-namespace-from',
                     ['@babel/plugin-transform-runtime', {
                         'helpers': true,
+                        'corejs': 3,
                         'regenerator': true
                     }]
                 ]


### PR DESCRIPTION
## What

- remove dependency `@babel/polyfill`
- add dependencies `core-js` `regenerator-runtime`

## Why

- `@babel/polyfill` has been deprecated as of 7.4.0

## Refs

- https://babeljs.io/docs/en/babel-polyfill
