### PR TITLE
Update rollup config to make @babel/env' target the latest browsers

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,8 +29,8 @@ const config = [
                         {
                             modules: false,
                             targets: {
-                                node: '8',
-                                browsers: 'last 2 versions'
+                                node: '8',  // Compile against node version 8 and up
+                                esmodules: true, // Target browsers supporting ES Modules. When specifying this option, the browsers field will be ignored.
                             }
                         }
                     ]


### PR DESCRIPTION
After trying different approaches I found this answer on StackOverflow. It turns out our @babel/env in rollup config is targeting old browsers. Changing the settings to transpile for browsers supporting ES Modules makes "regenerator is undefined" error gone.

Explanation is here. [](https://babeljs.io/docs/en/babel-preset-env)

@bguiz we'll need you to package the library and try again in Solange's code.