### PR TITLE
fix: expose utils on rsk3 instance

### DIFF
--- a/packages/rsk3/src/index.js
+++ b/packages/rsk3/src/index.js
@@ -32,6 +32,9 @@ export default class Rsk3 extends AbstractWeb3Module {
         this.accounts = new Accounts(resolvedProvider, null, options);
         this.personal = new Personal(resolvedProvider, null, this.accounts, options);
         this.abiCoder = new AbiCoder();
+        // utils singleton exposed via instance for backward compatibility with
+        // code written against web3.js
+        this.utils = Utils;
         // TODO: RNS here
         this.formatters = formatters;
         this.subscriptionsFactory = new SubscriptionsFactory(Utils, formatters);

--- a/packages/rsk3/tests/rsk3.test.js
+++ b/packages/rsk3/tests/rsk3.test.js
@@ -78,6 +78,9 @@ describe('rsk3Test', () => {
         expect(rsk3.abiCoder.constructor).toEqual(abiCoderMock);
 
         // Static property of Rsk3;
+        expect(rsk3.utils).toEqual(Utils);
+
+        // Static property of Rsk3;
         expect(Rsk3.utils).toEqual(Utils);
 
         expect(rsk3.formatters).toEqual(formatters);


### PR DESCRIPTION
## What

- Expose `utils` via `rsk3` instance (currently only exposed via class)
- Update release instructions in readme

## Why

- Existing web3.js code makes use of `web3.utils`, so this would be a convenience that improves portability

## Refs

- [Task](https://trello.com/c/ruv3rg8A/301)
- Related PRs: [json-rpc-web3js#3](https://github.com/rsksmart/json-rpc-web3js/pull/3), [#50](https://github.com/rsksmart/rsk3.js/pull/50)

