### PR TITLE
upgrade requested node version and npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.3.4",
   "description": "RSK JavaScript Wallet API repository",
   "engines": {
-    "node": ">=8.6.0"
+    "node": "10.13.0",
+    "npm": "6.9.0"
   },
   "main": "./packages/rsk3/src/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.3.4",
   "description": "RSK JavaScript Wallet API repository",
   "engines": {
-    "node": "10.13.0",
-    "npm": "6.9.0"
+    "node": ">= 10.13.0",
+    "npm": ">= 6.9.0"
   },
   "main": "./packages/rsk3/src/index.js",
   "directories": {


### PR DESCRIPTION
lower npm version will cause `cannot find module scrypt-shim` error

fix #53 